### PR TITLE
Update sodium and fix import paths

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
     "copyright": "Copyright © 2016, Thayne McCombs",
     "license": "ISC License",
     "dependencies": {
-        "sodium": "~>0.1.1"
+        "sodium:deimos": "~>0.1.4"
     },
     "targetType": "library"
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"sodium": "0.0.8"
+		"sodium": "0.1.4"
 	}
 }

--- a/source/chloride/auth.d
+++ b/source/chloride/auth.d
@@ -3,7 +3,7 @@ module chloride.auth;
 import chloride.core;
 import chloride.random : randomArray;
 
-import sodium.crypto_auth;
+import deimos.sodium.crypto_auth;
 
 ///
 unittest {

--- a/source/chloride/core.d
+++ b/source/chloride/core.d
@@ -4,7 +4,7 @@ import std.array : uninitializedArray;
 import std.string : fromStringz;
 import std.exception : ErrnoException;
 
-import sodium.core;
+import deimos.sodium.core;
 
 static this() {
     if (sodium_init() == -1) {

--- a/source/chloride/lockbox.d
+++ b/source/chloride/lockbox.d
@@ -5,7 +5,7 @@ import chloride.random : randomArray;
 
 import std.array : uninitializedArray;
 
-import sodium.crypto_box;
+import deimos.sodium.crypto_box;
 
 ///
 unittest {

--- a/source/chloride/password.d
+++ b/source/chloride/password.d
@@ -8,8 +8,8 @@ import std.algorithm.mutation : copy, fill;
 import std.exception: assumeUnique;
 import std.string : fromStringz, toStringz;
 
-import sodium.crypto_pwhash_scryptsalsa208sha256;
-import sodium.crypto_pwhash;
+import deimos.sodium.crypto_pwhash_scryptsalsa208sha256;
+import deimos.sodium.crypto_pwhash;
 
 /**
  * Algorithm to use for the password hashing.
@@ -214,7 +214,7 @@ bool verifyPassword(Algorithm alg, string password, string hash) {
 bool verifyPassword(string password, string hash) {
     import std.algorithm.searching;
     import std.conv;
-    import sodium.crypto_pwhash_argon2i;
+    import deimos.sodium.crypto_pwhash_argon2i;
 
     const ARGON_PREFIX = to!string(crypto_pwhash_argon2i_STRPREFIX);
     const SCRYPT_PREFIX = to!string(crypto_pwhash_scryptsalsa208sha256_STRPREFIX);

--- a/source/chloride/random.d
+++ b/source/chloride/random.d
@@ -5,7 +5,7 @@ import chloride.core;
 import std.array : uninitializedArray;
 import std.traits;
 
-import sodium.randombytes;
+import deimos.sodium.randombytes;
 
 
 /**

--- a/source/chloride/secretbox.d
+++ b/source/chloride/secretbox.d
@@ -5,7 +5,7 @@ import chloride.random : randomArray;
 
 import std.array;
 
-import sodium.crypto_secretbox;
+import deimos.sodium.crypto_secretbox;
 
 ///
 unittest {

--- a/source/chloride/sign.d
+++ b/source/chloride/sign.d
@@ -5,7 +5,7 @@ import chloride.random : randomArray;
 
 import std.array : uninitializedArray;
 
-import sodium.crypto_sign;
+import deimos.sodium.crypto_sign;
 
 ///
 unittest {


### PR DESCRIPTION
After updating to latest `sodium`, the current configuration of `chloride` doesn't compile